### PR TITLE
explicit cast argument to std::abs() in al_Functions.hpp to avoid amb…

### DIFF
--- a/include/al/core/math/al_Functions.hpp
+++ b/include/al/core/math/al_Functions.hpp
@@ -468,7 +468,7 @@ inline bool aeq(float a, float b, int maxULP){
   // Make ai and bi lexicographically ordered as a twos-complement int
   if(ai < 0) ai = 0x80000000 - ai;
   if(bi < 0) bi = 0x80000000 - bi;
-  return std::abs(ai - bi) <= maxULP;
+  return std::abs((float)(ai - bi)) <= maxULP;
 }
 
 inline bool aeq(double a, double b, int maxULP){
@@ -481,7 +481,7 @@ inline bool aeq(double a, double b, int maxULP){
   // Make ai and bi lexicographically ordered as a twos-complement int
   if(ai < 0) ai = 0x8000000000000000ULL - ai;
   if(bi < 0) bi = 0x8000000000000000ULL - bi;
-  return std::abs(ai - bi) <= maxULP;
+  return std::abs((double)(ai - bi)) <= maxULP;
 }
 
 TEM inline T atLeast(const T& v, const T& e){ return (v >= T(0)) ? std::max(v, e) : std::min(v, -e); }
@@ -671,7 +671,7 @@ TEM T legendreP(int l, int m, T ct, T st){
   //    P_{m+1}^m(x) = x(2m+1) P_m^m(x).
 
   T P = 0;        // the result
-  int M = std::abs(m);   // M = |m|
+  int M = std::abs((double)m);   // M = |m|
   T y1 = 1.;        // recursion state variable
 
   for(int i=1; i<=M; ++i)


### PR DESCRIPTION
…iguous type error in clang on osx. 

The cmake settings and the build errors were as follows:

-- The C compiler identification is AppleClang 6.1.0.6020053
-- The CXX compiler identification is AppleClang 6.1.0.6020053
-- Check for working C compiler: /Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
MACOS
-- Found OpenGL: /System/Library/Frameworks/OpenGL.framework  
-- Found GLEW: /usr/local/include  
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.29.2") 
-- Checking for one of the modules 'glfw3'
-- Checking for module 'libassimp'
--   No package 'libassimp' found
-- Assimp 3 found
found freeimage
found assimp
found freetype
Using RtMidi
Using RtAudio
-- Configuring done
-- Generating done

...

make 

...

In file included from /Users/grrrwaaa/code/allolib/src/util/al_Array.cpp:2:
In file included from /Users/grrrwaaa/code/allolib/include/al/util/al_Array.hpp:49:
/Users/grrrwaaa/code/allolib/include/al/core/math/al_Functions.hpp:471:10: error: call to 'abs' is
      ambiguous
  return std::abs(ai - bi) <= maxULP;
         ^~~~~~~~
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:660:1: note: 
      candidate function
abs(float __x) _NOEXCEPT {return fabsf(__x);}
^
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:664:1: note: 
      candidate function
abs(double __x) _NOEXCEPT {return fabs(__x);}
^
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:668:1: note: 
      candidate function
abs(long double __x) _NOEXCEPT {return fabsl(__x);}
^
In file included from /Users/grrrwaaa/code/allolib/src/util/al_Array.cpp:2:
In file included from /Users/grrrwaaa/code/allolib/include/al/util/al_Array.hpp:49:
/Users/grrrwaaa/code/allolib/include/al/core/math/al_Functions.hpp:484:10: error: call to 'abs' is
      ambiguous
  return std::abs(ai - bi) <= maxULP;
         ^~~~~~~~
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:660:1: note: 
      candidate function
abs(float __x) _NOEXCEPT {return fabsf(__x);}
^
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:664:1: note: 
      candidate function
abs(double __x) _NOEXCEPT {return fabs(__x);}
^
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:668:1: note: 
      candidate function
abs(long double __x) _NOEXCEPT {return fabsl(__x);}
^
In file included from /Users/grrrwaaa/code/allolib/src/util/al_Array.cpp:2:
In file included from /Users/grrrwaaa/code/allolib/include/al/util/al_Array.hpp:49:
/Users/grrrwaaa/code/allolib/include/al/core/math/al_Functions.hpp:674:11: error: call to 'abs' is
      ambiguous
  int M = std::abs((int)m);   // M = |m|
          ^~~~~~~~
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:660:1: note: 
      candidate function
abs(float __x) _NOEXCEPT {return fabsf(__x);}
^
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:664:1: note: 
      candidate function
abs(double __x) _NOEXCEPT {return fabs(__x);}
^
/Applications/Xcode6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:668:1: note: 
      candidate function
abs(long double __x) _NOEXCEPT {return fabsl(__x);}
^
3 errors generated.
make[2]: *** [CMakeFiles/al.dir/src/util/al_Array.cpp.o] Error 1
make[1]: *** [CMakeFiles/al.dir/all] Error 2
make: *** [all] Error 2