### PR TITLE
a missing #define to check AL_WINDOWS breaks windows build

### DIFF
--- a/include/al/util/ui/al_HtmlInterfaceServer.hpp
+++ b/include/al/util/ui/al_HtmlInterfaceServer.hpp
@@ -106,7 +106,11 @@ private:
 
 	std::string mRootPath;
 	std::string mNodeJsPath;
+#ifndef AL_WINDOWS
 	pid_t  mPid;
+#else
+	// TODO: Windows equivalent
+#endif
 	int p_stdin[2], p_stdout[2];
 
 	int mInterfaceSendPort; // Interface.js sends OSC on this port


### PR DESCRIPTION
pid_t doesn't exist for windows. 

Gently #defined it out just like how the rest of the file handles it