### PR TITLE
Added #include <cstring> to src/ui/al_Parameter.cpp

### DIFF
--- a/src/ui/al_Parameter.cpp
+++ b/src/ui/al_Parameter.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <regex>
 #include <sstream>
+#include <cstring>
 
 #include "al/io/al_File.hpp"
 


### PR DESCRIPTION
`gcc (Debian 12.2.0-14) 12.2.0` throws an error asking for the include of `<cstring>` in `src/ui/al_Parameter.cpp`. 