### PR TITLE
Add `#include <cstring>`  to `src/ui/al_Parameter.cpp`

### DIFF
--- a/src/ui/al_Parameter.cpp
+++ b/src/ui/al_Parameter.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <regex>
 #include <sstream>
+#include <cstring>
 
 #include "al/io/al_File.hpp"
 


### PR DESCRIPTION
When trying to build AlloLib projects on my Raspberry Pis, the compilers complain (`error`, not `warning`) about explicitly `#include`ing `<cstring>` in `src/ui/al_Parameter.cpp`. 

### Specs of systems tested on:

- Raspberry Pi 4b running PatchboxOS
- Raspberry Pi 4b running Raspberry Pi OS Lite