### PR TITLE
Build on GCC 15.2.0 / Ubuntu 26.04 LTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(allolib)
+
+# Tells third-party submodules (Gamma, cpptoml, json, oscpack) to
+# override their cmake_minimum_required(VERSION < 3.5) policy.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+set(OpenGL_GL_PREFERENCE GLVND)
 
 MACRO(MACRO_ENSURE_OUT_OF_SOURCE_BUILD MSG)
      STRING(COMPARE EQUAL "${CMAKE_SOURCE_DIR}"

--- a/include/al/app/al_DistributedApp.hpp
+++ b/include/al/app/al_DistributedApp.hpp
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+#include <cstdint>
 #include <map>
 
 #include "al/app/al_App.hpp"

--- a/include/al/app/al_NodeConfiguration.hpp
+++ b/include/al/app/al_NodeConfiguration.hpp
@@ -2,6 +2,7 @@
 #define INCLUDE_AL_NODECONFIGURATION
 
 #include <cinttypes>
+#include <cstdint>
 #include <iostream>
 
 namespace al {

--- a/include/al/app/al_OSCDomain.hpp
+++ b/include/al/app/al_OSCDomain.hpp
@@ -2,6 +2,7 @@
 #define OSCDOMAIN_H
 
 #include <functional>
+#include <cstdint>
 #include <iostream>
 
 #include "al_ComputationDomain.hpp"

--- a/include/al/app/al_StateDistributionDomain.hpp
+++ b/include/al/app/al_StateDistributionDomain.hpp
@@ -2,6 +2,7 @@
 #define STATEDISTRIBUTIONDOMAIN_H
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <iostream>

--- a/include/al/io/al_Arduino.hpp
+++ b/include/al/io/al_Arduino.hpp
@@ -2,6 +2,7 @@
 #define AL_ARDUINO_HPP
 
 #include <functional>
+#include <cstdint>
 #include <thread>
 
 #include "serial/serial.h"

--- a/include/al/io/al_AudioIOData.hpp
+++ b/include/al/io/al_AudioIOData.hpp
@@ -46,6 +46,7 @@
 */
 
 #include <cassert>
+#include <cstdint>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>

--- a/include/al/io/al_PersistentConfig.hpp
+++ b/include/al/io/al_PersistentConfig.hpp
@@ -2,6 +2,7 @@
 #define INCLUDE_PERSISTENTCONFIG_HPP
 
 #include <cinttypes>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/include/al/io/al_Socket.hpp
+++ b/include/al/io/al_Socket.hpp
@@ -46,6 +46,7 @@
 */
 
 #include <string>
+#include <cstdint>
 
 #include "al/system/al_Time.hpp"
 #include "al/types/al_ValueSource.hpp"

--- a/include/al/math/al_Functions.hpp
+++ b/include/al/math/al_Functions.hpp
@@ -44,6 +44,7 @@
 */
 
 #include <algorithm>
+#include <cstdint>
 #include <cmath>
 
 #include "al/math/al_Constants.hpp"

--- a/include/al/math/al_Random.hpp
+++ b/include/al/math/al_Random.hpp
@@ -43,6 +43,7 @@
 */
 
 #include "al/math/al_StdRandom.hpp"
+#include <cstdint>
 
 /* req'd for int to float conversion */
 #include <time.h> /* req'd for time() */

--- a/include/al/protocol/al_CommandConnection.hpp
+++ b/include/al/protocol/al_CommandConnection.hpp
@@ -47,6 +47,8 @@
 */
 
 #include <atomic>
+#include <cstdint>
+#include <cstring>
 #include <cinttypes>
 #include <condition_variable>
 #include <iostream>

--- a/include/al/protocol/al_OSC.hpp
+++ b/include/al/protocol/al_OSC.hpp
@@ -47,6 +47,7 @@
 */
 
 #include <memory>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/al/protocol/al_Serialize.hpp
+++ b/include/al/protocol/al_Serialize.hpp
@@ -43,6 +43,7 @@
 */
 
 #include <string>
+#include <cstdint>
 #include <vector>
 #include "al_Serialize.h"
 

--- a/include/al/scene/al_PolySynth.hpp
+++ b/include/al/scene/al_PolySynth.hpp
@@ -42,6 +42,7 @@
 */
 
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <thread>

--- a/include/al/sound/al_Ambisonics.hpp
+++ b/include/al/sound/al_Ambisonics.hpp
@@ -50,6 +50,7 @@
 */
 
 #include <stdio.h>
+#include <cstring>
 
 #include <iostream>
 

--- a/include/al/sound/al_DownMixer.hpp
+++ b/include/al/sound/al_DownMixer.hpp
@@ -2,6 +2,7 @@
 #define INCLUDE_AL_DOWNMIXER_HPP
 
 #include <map>
+#include <cstdint>
 #include <vector>
 
 #include "al/sound/al_Speaker.hpp"

--- a/include/al/sound/al_SoundFile.hpp
+++ b/include/al/sound/al_SoundFile.hpp
@@ -2,6 +2,7 @@
 #define INCLUDE_AL_SOUNDFILE_HPP
 
 #include <atomic>
+#include <cstdint>
 #include <vector>
 
 namespace al {

--- a/include/al/sound/al_SpeakerAdjustment.hpp
+++ b/include/al/sound/al_SpeakerAdjustment.hpp
@@ -2,6 +2,7 @@
 #define AL_SPEAKERADJUSTMENT
 
 #include <vector>
+#include <cstdint>
 
 #include "al/io/al_AudioIOData.hpp"
 #include "al/sound/al_Speaker.hpp"

--- a/include/al/spatial/al_HashSpace.hpp
+++ b/include/al/spatial/al_HashSpace.hpp
@@ -2,6 +2,7 @@
 #define INCLUDE_AL_HASHSPACE_HPP
 
 #include <algorithm>
+#include <cstdint>
 #include <vector>
 
 #include "al/math/al_Vec.hpp"

--- a/include/al/sphere/al_Meter.hpp
+++ b/include/al/sphere/al_Meter.hpp
@@ -42,6 +42,7 @@
 */
 
 #include "al/graphics/al_Graphics.hpp"
+#include <cstring>
 #include "al/graphics/al_Mesh.hpp"
 #include "al/graphics/al_Shapes.hpp"
 #include "al/io/al_AudioIOData.hpp"

--- a/include/al/types/al_Buffer.hpp
+++ b/include/al/types/al_Buffer.hpp
@@ -45,6 +45,7 @@
 */
 
 #include <algorithm>
+#include <cstring>
 #include <vector>
 
 namespace al {

--- a/include/al/types/al_SingleRWRingBuffer.hpp
+++ b/include/al/types/al_SingleRWRingBuffer.hpp
@@ -45,6 +45,7 @@
 */
 
 #include <cstring>
+#include <cstdint>
 #include <inttypes.h>
 #include <vector>
 

--- a/include/al/types/al_ValueSource.hpp
+++ b/include/al/types/al_ValueSource.hpp
@@ -1,5 +1,7 @@
 #ifndef AL_VALUESOURCE_HPP
 #define AL_VALUESOURCE_HPP
+#include <cstdint>
+#include <string>
 
 namespace al {
 struct ValueSource {

--- a/include/al/types/al_Voxels.hpp
+++ b/include/al/types/al_Voxels.hpp
@@ -48,6 +48,7 @@
 #define INCLUDE_ALLO_VOXELS_HPP
 
 #include <cmath>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/include/al/ui/al_DiscreteParameterValues.hpp
+++ b/include/al/ui/al_DiscreteParameterValues.hpp
@@ -2,6 +2,7 @@
 #define AL_DISCRETEPARAMETERVALUES_HPP
 
 #include <iostream>
+#include <cstdint>
 #include <mutex>
 #include <string>
 #include <vector>

--- a/include/al/ui/al_Parameter.hpp
+++ b/include/al/ui/al_Parameter.hpp
@@ -43,6 +43,7 @@
 */
 
 #include <float.h>
+#include <cstdint>
 
 #include <algorithm>
 #include <atomic>

--- a/include/al/ui/al_ParameterGUI.hpp
+++ b/include/al/ui/al_ParameterGUI.hpp
@@ -41,6 +41,7 @@
 */
 
 #include <climits>
+#include <cstdint>
 
 #include "al/io/al_AudioIO.hpp"
 #include "al/io/al_ControlNav.hpp"

--- a/include/al/ui/al_ParameterServer.hpp
+++ b/include/al/ui/al_ParameterServer.hpp
@@ -43,6 +43,7 @@
 */
 
 #include <mutex>
+#include <cstdint>
 
 #include "al/protocol/al_OSC.hpp"
 #include "al/ui/al_Parameter.hpp"

--- a/include/al/ui/al_PresetHandler.hpp
+++ b/include/al/ui/al_PresetHandler.hpp
@@ -41,6 +41,7 @@
 */
 
 #include <algorithm>
+#include <cstdint>
 #include <atomic>
 #include <condition_variable>
 #include <functional>

--- a/include/al/ui/al_PresetSequencer.hpp
+++ b/include/al/ui/al_PresetSequencer.hpp
@@ -44,6 +44,7 @@
 */
 
 #include <atomic>
+#include <cstdint>
 #include <condition_variable>
 #include <functional>
 #include <future>

--- a/src/app/al_AppRecorder.cpp
+++ b/src/app/al_AppRecorder.cpp
@@ -1,6 +1,7 @@
 ﻿#include "al/app/al_AppRecorder.hpp"
 
 #include "al/graphics/al_Image.hpp"
+#include <cstdint>
 
 #include "Gamma/SoundFile.h"
 

--- a/src/app/al_DistributedApp.cpp
+++ b/src/app/al_DistributedApp.cpp
@@ -1,4 +1,5 @@
 #include "al/app/al_DistributedApp.hpp"
+#include <cstdint>
 
 #include "al/sphere/al_SphereUtils.hpp"
 

--- a/src/app/al_OSCDomain.cpp
+++ b/src/app/al_OSCDomain.cpp
@@ -1,4 +1,5 @@
 #include "al/app/al_OSCDomain.hpp"
+#include <cstdint>
 
 using namespace al;
 

--- a/src/graphics/al_Image.cpp
+++ b/src/graphics/al_Image.cpp
@@ -1,4 +1,5 @@
 #include "al/graphics/al_Image.hpp"
+#include <cstdint>
 
 #include <cstring>
 #include <iostream>

--- a/src/graphics/al_stb_font.cpp
+++ b/src/graphics/al_stb_font.cpp
@@ -1,6 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 #include "al_stb_font.hpp"
+#include <cstdint>
 #include <cstddef>  // offsetof
 #include <iostream>
 

--- a/src/io/al_Arduino.cpp
+++ b/src/io/al_Arduino.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 //#include <functional>

--- a/src/io/al_AudioIOData.cpp
+++ b/src/io/al_AudioIOData.cpp
@@ -1,4 +1,5 @@
 #include "al/io/al_AudioIOData.hpp"
+#include <cstdint>
 
 #include <algorithm>
 #include <cassert>

--- a/src/io/al_CSVReader.cpp
+++ b/src/io/al_CSVReader.cpp
@@ -1,4 +1,6 @@
 #include "al/io/al_CSVReader.hpp"
+#include <cstdint>
+#include <cstring>
 
 #include <cassert>
 #include <cctype>

--- a/src/io/al_PersistentConfig.cpp
+++ b/src/io/al_PersistentConfig.cpp
@@ -1,4 +1,5 @@
 #include "al/io/al_PersistentConfig.hpp"
+#include <cstdint>
 
 using namespace al;
 

--- a/src/io/al_Socket.cpp
+++ b/src/io/al_Socket.cpp
@@ -33,6 +33,7 @@ does not perform any handshake for connection.)
 
 #else
 #include <sys/ioctl.h>
+#include <cstdint>
 #endif
 
 #include "al/io/al_Socket.hpp"

--- a/src/io/al_Toml.cpp
+++ b/src/io/al_Toml.cpp
@@ -1,4 +1,5 @@
 #include "al/io/al_Toml.hpp"
+#include <cstdint>
 
 static al::TomlLoader& global_toml_loader() {
   static al::TomlLoader root = []() {

--- a/src/protocol/al_CommandConnection.cpp
+++ b/src/protocol/al_CommandConnection.cpp
@@ -1,4 +1,6 @@
 #include "al/protocol/al_CommandConnection.hpp"
+#include <cstdint>
+#include <cstring>
 
 #include <algorithm>
 #include <array>

--- a/src/protocol/al_OSC.cpp
+++ b/src/protocol/al_OSC.cpp
@@ -1,4 +1,5 @@
 #include "al/protocol/al_OSC.hpp"
+#include <cstdint>
 
 #include <ctype.h> // isgraph
 #include <stdio.h> // printf

--- a/src/protocol/al_Serialize.cpp
+++ b/src/protocol/al_Serialize.cpp
@@ -1,4 +1,6 @@
 #include "al/core/protocol/al_Serialize.h"
+#include <cstdint>
+#include <cstring>
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/src/scene/al_DistributedScene.cpp
+++ b/src/scene/al_DistributedScene.cpp
@@ -1,4 +1,5 @@
 #include "al/scene/al_DistributedScene.hpp"
+#include <cstdint>
 
 using namespace al;
 

--- a/src/scene/al_PolySynth.cpp
+++ b/src/scene/al_PolySynth.cpp
@@ -1,4 +1,6 @@
 #include "al/scene/al_PolySynth.hpp"
+#include <cstdint>
+#include <cstring>
 
 #include <memory>
 

--- a/src/scene/al_SynthSequencer.cpp
+++ b/src/scene/al_SynthSequencer.cpp
@@ -1,5 +1,6 @@
 
 #include "al/scene/al_SynthSequencer.hpp"
+#include <cstdint>
 
 #include <algorithm>
 #include <cassert>

--- a/src/scene/al_SynthVoice.cpp
+++ b/src/scene/al_SynthVoice.cpp
@@ -1,4 +1,6 @@
 #include "al/scene/al_PolySynth.hpp"
+#include <cstdint>
+#include <cstring>
 
 #include <memory>
 

--- a/src/sound/al_DownMixer.cpp
+++ b/src/sound/al_DownMixer.cpp
@@ -1,5 +1,7 @@
 
 #include "al/sound/al_DownMixer.hpp"
+#include <cstdint>
+#include <cstring>
 #include "al/io/al_AudioIOData.hpp"
 
 #include <cinttypes>

--- a/src/spatial/al_HashSpace.cpp
+++ b/src/spatial/al_HashSpace.cpp
@@ -1,4 +1,5 @@
 #include "al/spatial/al_HashSpace.hpp"
+#include <cstdint>
 #include "al/math/al_Functions.hpp"
 
 using namespace al;

--- a/src/sphere/al_SphereUtils.cpp
+++ b/src/sphere/al_SphereUtils.cpp
@@ -1,6 +1,7 @@
 
 #define GLFW_INCLUDE_NONE
 #include "al/sphere/al_SphereUtils.hpp"
+#include <cstdint>
 
 // gethostname
 #ifdef AL_WINDOWS

--- a/src/system/al_Printing.cpp
+++ b/src/system/al_Printing.cpp
@@ -1,4 +1,5 @@
 #include "al/system/al_Printing.hpp"
+#include <cstdint>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/types/al_VariantValue.cpp
+++ b/src/types/al_VariantValue.cpp
@@ -1,5 +1,6 @@
 
 #include <iostream>
+#include <cstdint>
 #include <stdexcept>
 
 #include "al/types/al_VariantValue.hpp"

--- a/src/types/al_Voxels.cpp
+++ b/src/types/al_Voxels.cpp
@@ -1,4 +1,6 @@
 #include "al/util/al_Voxels.hpp"
+#include <cstdint>
+#include <cstring>
 #include "al/core/io/al_File.hpp"
 #include "al/core/system/al_Printing.hpp"
 #include "al/util/al_Image.hpp"

--- a/src/ui/al_Composition.cpp
+++ b/src/ui/al_Composition.cpp
@@ -1,8 +1,10 @@
 #include "al/ui/al_Composition.hpp"
 
+#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 #include "al/io/al_File.hpp"
 #include "al/system/al_Time.hpp"

--- a/src/ui/al_DiscreteParameterValues.cpp
+++ b/src/ui/al_DiscreteParameterValues.cpp
@@ -1,4 +1,5 @@
 #include "al/ui/al_DiscreteParameterValues.hpp"
+#include <cstdint>
 
 #include <algorithm>
 #include <cassert>

--- a/src/ui/al_Parameter.cpp
+++ b/src/ui/al_Parameter.cpp
@@ -1,5 +1,7 @@
 
 #include "al/ui/al_Parameter.hpp"
+#include <cstdint>
+#include <cstring>
 
 #include <fstream>
 #include <iostream>

--- a/src/ui/al_ParameterBundle.cpp
+++ b/src/ui/al_ParameterBundle.cpp
@@ -1,5 +1,6 @@
 
 #include "al/ui/al_ParameterBundle.hpp"
+#include <cstdint>
 
 #include <cstring>
 #include <string>

--- a/src/ui/al_ParameterGUI.cpp
+++ b/src/ui/al_ParameterGUI.cpp
@@ -1,4 +1,6 @@
 #include "al/ui/al_ParameterGUI.hpp"
+#include <cstdint>
+#include <cstring>
 
 #include <string>
 

--- a/src/ui/al_ParameterServer.cpp
+++ b/src/ui/al_ParameterServer.cpp
@@ -1,5 +1,6 @@
 
 #include "al/ui/al_ParameterServer.hpp"
+#include <cstdint>
 #include "al/io/al_Socket.hpp"
 
 #include <algorithm>

--- a/src/ui/al_PresetHandler.cpp
+++ b/src/ui/al_PresetHandler.cpp
@@ -1,5 +1,6 @@
 
 #include "al/ui/al_PresetHandler.hpp"
+#include <cstdint>
 
 #include <cassert>
 #include <chrono>

--- a/src/ui/al_SequenceRecorder.cpp
+++ b/src/ui/al_SequenceRecorder.cpp
@@ -1,5 +1,6 @@
 
 #include "al/ui/al_SequenceRecorder.hpp"
+#include <cstring>
 
 #include <cassert>
 #include <fstream>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
+  GIT_TAG        release-1.12.1
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
There are lots of compile errors like these:

    error: 'uint16_t' does not name a type
    error: 'strcmp' was not declared in this scope

...because our code was relying on old, lax compiler behavior. Since gcc 13, libstdc++ no longer includes `<cstdint>` and `<cstring>` so we have to explicitly include these in files that use these types and functions.

Also, basically everybody has CMake 4+ now, so I bumped that.

I had to update the gtest version because the old gtest had the same `<cstdint>` compiler errors.

This change was also tested on....

- GCC 11.4.0 / Ubuntu 22.04 LTS (gr05)
- Apple clang 9 / macOS Mojave 10.14 (ar01)
- Visual Studio 2026 / MSVC 14.51
- Apple clang 21 / macOS Tahoe 26.5.1

Look for a similar PR for the devel branch.
